### PR TITLE
Fix: bucket mount path to match chroma persist path

### DIFF
--- a/deploy-template.yaml
+++ b/deploy-template.yaml
@@ -30,14 +30,14 @@ spec:
         - name: CHROMA_SERVER_AUTHN_PROVIDER
           value: chromadb.auth.token_authn.TokenAuthenticationServerProvider
         - name: PERSIST_DIRECTORY
-          value: /db_path
+          value: /data
         resources:
           limits:
             cpu: 1000m
             memory: 4Gi
         volumeMounts:
         - name: gcs-1
-          mountPath: /db_path
+          mountPath: /data
         startupProbe:
           timeoutSeconds: 240
           periodSeconds: 240


### PR DESCRIPTION
Fix data persist path to match where chromadb is storing data. 

Even though there was an attempt to remap it using the `PERSIST_DIRECTORY`, it wasn't working. So we just matched it to the one in logs.

This is what I saw in cloudrun logs
![image](https://github.com/user-attachments/assets/164ce7bf-ce9d-40ef-85e2-bd4bca33b39d)

after fixing this path we can now see that it's available in gcs
![image](https://github.com/user-attachments/assets/ccefa9e1-6e97-4a7e-9eba-d1fb1041362d)
